### PR TITLE
Default service name can cause accidental deletion of wrong service b…

### DIFF
--- a/jobs/broker-deregistrar/spec
+++ b/jobs/broker-deregistrar/spec
@@ -15,4 +15,3 @@ properties:
     description: 'Name of the service broker'
   redis.broker.service_name:
     description: 'Service name'
-    default: p-redis


### PR DESCRIPTION
…roker + instances

This default value sadly accidentally caused us to delete all the instances of `p-redis` when we were trying to deregister a different service broker.
