### PR TITLE
allow configureable smoke test password

### DIFF
--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -24,3 +24,6 @@ properties:
   redis.broker.dedicated_nodes:
     description: List of node IPs for the dedicated plan
     default: []
+  smoke_test_password:
+    description: 'Password for smoke-tests only to comply with CF password policy, if exists.'
+    default: "meow"

--- a/jobs/smoke-tests/templates/config.json.erb
+++ b/jobs/smoke-tests/templates/config.json.erb
@@ -8,6 +8,7 @@
   "admin_user":     "<%= p('cf.admin_username') %>",
   "admin_password": "<%= p('cf.admin_password') %>",
   "service_name":   "<%= p('redis.broker.service_name') %>",
+  "test_password":  "<%= p('smoke_test_password') %>",
   "plan_names": [
     <% if shared_vm_plan_enabled %>"shared-vm"<% end %><% if shared_vm_plan_enabled && dedicated_vm_plan_enabled %>,<% end %>
     <% if dedicated_vm_plan_enabled %>"dedicated-vm"<% end %>


### PR DESCRIPTION
CFv213 onwards allows for an optional password policy.
Service releases which use the cf-test-helpers suite should
be able to overwrite the suite's default password (meow) to
avoid failure.

Connected to cloudfoundry-incubator/cf-test-helpers#16