### PR TITLE
Guarantee correct redis host IP by self-lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ director_uuid: REPLACE_WITH_DIRECTOR_ID
 
 2. You can increase the count of the `dedicated-vm` plan nodes from the example of `1`
 
-**Note:** If your bosh-lite does not have enough capacity to handle the increased nodes resource requirements, your deployment will likely fail. 
+**Note:** If your bosh-lite does not have enough capacity to handle the increased nodes resource requirements, your deployment will likely fail.
 
 ```
 jobs:
@@ -47,7 +47,6 @@ You must also add these additional IPs in the properties block at the end of the
 
 ```
   redis:
-    host: 10.244.3.46
     maxmemory: 262144000
     config_command: config
     save_command: save
@@ -62,14 +61,14 @@ You must also add these additional IPs in the properties block at the end of the
 
 ```
       backups:
-        path: 
-        access_key_id: 
-        secret_access_key: 
-        endpoint_url: 
-        bucket_name: 
+        path:
+        access_key_id:
+        secret_access_key:
+        endpoint_url:
+        bucket_name:
 ```
 
-If these values are not populated, the scheduled backups will not run. 
+If these values are not populated, the scheduled backups will not run.
 
 
 ### Properties

--- a/jobs/cf-redis-broker/spec
+++ b/jobs/cf-redis-broker/spec
@@ -35,8 +35,6 @@ properties:
   redis.log_directory:
     default: /var/vcap/sys/log/redis
     description: The directory which stores the redis server logs
-  redis.host:
-    description: This host which the Redis server runs on
   redis.conf_path:
     default: /var/vcap/jobs/cf-redis-broker/config/redis.conf
     description: The shared conf file for all Redis instances

--- a/jobs/cf-redis-broker/templates/broker.yml.erb
+++ b/jobs/cf-redis-broker/templates/broker.yml.erb
@@ -4,7 +4,7 @@ redis:
   service_id: <%= p('redis.broker.service_id') %>
   shared_vm_plan_id: <%= p('redis.broker.shared_vm_plan_id') %>
   dedicated_vm_plan_id: <%= p('redis.broker.dedicated_vm_plan_id') %>
-  host: <%= p('redis.host') %>
+  host: <%= spec.networks.send(spec.networks.methods(false).first).ip %>
   data_directory: <%= p('redis.data_directory') %>
   redis_conf_path: <%= p('redis.conf_path') %>
   log_directory: <%= p('redis.log_directory') %>

--- a/manifests/cf-redis-aws.yml
+++ b/manifests/cf-redis-aws.yml
@@ -131,7 +131,6 @@ properties:
       username: REPLACE_WITH_NATS_USERNAME
       password: REPLACE_WITH_NATS_PASSWORD
   redis:
-    host: 10.10.32.12
     broker:
       network: services
       service_instance_limit: 5

--- a/manifests/cf-redis-lite.yml
+++ b/manifests/cf-redis-lite.yml
@@ -170,7 +170,6 @@ properties:
       username: nats
       password: nats
   redis:
-    host: 10.244.3.46
     maxmemory: 262144000
     config_command: config
     save_command: save
@@ -185,8 +184,8 @@ properties:
         username: admin
         password: admin
       backups:
-        path: 
-        access_key_id: 
-        secret_access_key: 
-        endpoint_url: 
-        bucket_name: 
+        path:
+        access_key_id:
+        secret_access_key:
+        endpoint_url:
+        bucket_name:


### PR DESCRIPTION
Manually requiring the correct IP has led to hours of debugging
in the past - as the broker quietly blocks trying to access its newly
spawned redis-server on the wrong IP.

This PR automatically looks up the correct IP at template rendering time.

As a bonus (and the other motivation for the PR) this allows additional
cf-redis-broker/1, cf-redis-broker/2 jobs to be run - each having the correct
local IP (rather than an erroneous shared IP); which allows them to be
hosted behind the new cf-subway multiplexing broker.