### PR TITLE
Change external domain to be YOUR_CF_APPS_DOMAIN

### DIFF
--- a/templates/sample_stubs/sample_aws_stub.yml
+++ b/templates/sample_stubs/sample_aws_stub.yml
@@ -1,6 +1,6 @@
 meta:
   environment: YOUR_ENVIRONMENT_NAME
-  external_domain: YOUR_CF_SYSTEM_DOMAIN
+  external_domain: YOUR_CF_APPS_DOMAIN
   apps_domain: YOUR_CF_APPS_DOMAIN
   nats:
     host: 10.0.16.11


### PR DESCRIPTION
Change external domain to be YOUR_CF_APPS_DOMAIN in place of YOUR_CF_SYSTEM_DOMAIN.

The broker register errand fails when using system domain for the external domain. 