### PR TITLE
Add the possibility to deploy cf-redis with an OpenStack IaaS

### DIFF
--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -23,8 +23,9 @@ fi
 if [ "$infrastructure" != "aws" ] && \
    [ "$infrastructure" != "azure" ] && \
    [ "$infrastructure" != "warden" ] && \
+   [ "$infrastructure" != "openstack" ] && \
    [ "$infrastructure" != "vsphere" ] ; then
- echo "usage: ${0} <aws|azure|warden|vsphere> [stubs...]"
+ echo "usage: ${0} <aws|azure|warden|openstack|vsphere> [stubs...]"
  exit 1
 fi
 

--- a/templates/sample_stubs/infrastructure-openstack.yml
+++ b/templates/sample_stubs/infrastructure-openstack.yml
@@ -1,0 +1,30 @@
+---
+meta: ~
+
+compilation:
+  cloud_properties:
+    instance_type: (( merge || "m3.medium" ))
+
+resource_pools:
+- name: redis_z1
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: (( merge || "latest" ))
+  cloud_properties:
+    instance_type: (( merge || "m3.medium" ))
+
+networks:
+- name: redis_z1
+  type: manual
+  subnets:
+  - range: 10.0.16.0/20
+    gateway: 10.0.16.1
+    reserved:
+    - 10.0.16.2 - 10.0.16.254
+    static:
+    - 10.0.17.1 - 10.0.17.100
+    dns:
+    - 10.0.0.2
+    cloud_properties:
+      subnet: YOUR_SUBNET_ID
+      security_group: YOUR_SECURITY_GROUP_NAME


### PR DESCRIPTION
Currently the templates and the manifest generation script can't deal with an OpenStack IaaS. This PR intends to support it.