### PR TITLE
updated deployment_name description in sample stubs

### DIFF
--- a/templates/sample_stubs/meta-aws.yml
+++ b/templates/sample_stubs/meta-aws.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME # do not use cf deployment name
+  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME
   director_uuid: REPLACE_WITH_DIRECTOR_ID
   release_name: cf-redis
   release_version: REPLACE_WITH_REDIS_RELEASE_VERSION # Optional, you can delete this property to always get latest

--- a/templates/sample_stubs/meta-aws.yml
+++ b/templates/sample_stubs/meta-aws.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  deployment_name: REPLACE_WITH_CF_DEPLOYMENT_NAME
+  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME # do not use cf deployment name
   director_uuid: REPLACE_WITH_DIRECTOR_ID
   release_name: cf-redis
   release_version: REPLACE_WITH_REDIS_RELEASE_VERSION # Optional, you can delete this property to always get latest

--- a/templates/sample_stubs/meta-openstack.yml
+++ b/templates/sample_stubs/meta-openstack.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME # do not use cf deployment name
+  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME
   director_uuid: REPLACE_WITH_DIRECTOR_ID
   release_name: cf-redis
   apps_domain: REPLACE_WITH_APP_DOMAIN

--- a/templates/sample_stubs/meta-openstack.yml
+++ b/templates/sample_stubs/meta-openstack.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  deployment_name: REPLACE_WITH_CF_DEPLOYMENT_NAME
+  deployment_name: REPLACE_WITH_REDIS_DEPLOYMENT_NAME # do not use cf deployment name
   director_uuid: REPLACE_WITH_DIRECTOR_ID
   release_name: cf-redis
   apps_domain: REPLACE_WITH_APP_DOMAIN


### PR DESCRIPTION
if you use cf deployment name in redis manifest, your cf deployment will be removed after redis compilation step.