### PR TITLE
Configurable shared instance ports

### DIFF
--- a/jobs/cf-redis-broker/spec
+++ b/jobs/cf-redis-broker/spec
@@ -143,6 +143,12 @@ properties:
   redis.broker.start_redis_timeout:
     description: Maximum wait time in seconds for Redis to start up
     default: 600
+  redis.broker.shared_min_port:
+    description: The preferred lower port range to allocate for shared instances (e.g. "30000"). If no free port is available within this range, the service instance creation request will fail.
+    default: 1024
+  redis.broker.shared_max_port:
+    description: The preferred upper port range to allocate for shared instances (e.g. "40000"). If no free port is available within the preferred range, the service instance creation request will fail.
+    default: 65535
   redis.broker.service_instance_limit:
     description: The maximum number of instances allowed
   redis.broker.auth.username:

--- a/jobs/cf-redis-broker/templates/broker.yml.erb
+++ b/jobs/cf-redis-broker/templates/broker.yml.erb
@@ -36,6 +36,8 @@ redis:
   long_description: <%= p('redis.broker.long_description') %>
   description: <%= p('redis.broker.description') %>
   icon_image: <%= p('redis.broker.icon_image') %>
+  shared_min_port: <%= p('redis.broker.shared_min_port') %>
+  shared_max_port: <%= p('redis.broker.shared_max_port') %>
   dedicated:
     nodes: <%= p('redis.broker.dedicated_nodes') %>
     port: <%= p('redis.broker.dedicated_port') %>

--- a/templates/sample_stubs/meta-aws.yml
+++ b/templates/sample_stubs/meta-aws.yml
@@ -34,6 +34,8 @@ meta:
       service_id: 7aba7e52-f61b-4263-9de1-14e9d11fb67d
       shared_vm_plan_id: 78bf886c-bc50-4f31-a03c-cb786a158286
       dedicated_vm_plan_id: 48b35349-d3de-4e19-bc4a-66996ae07766
+      shared_min_port: 1024
+      shared_max_port: 65535
     dedicated_plan:
       instance_count: 2
     shared_plan:

--- a/templates/sample_stubs/meta-openstack.yml
+++ b/templates/sample_stubs/meta-openstack.yml
@@ -35,6 +35,8 @@ meta:
       service_id: 7aba7e52-f61b-4263-9de1-14e9d11fb67d
       shared_vm_plan_id: 78bf886c-bc50-4f31-a03c-cb786a158286
       dedicated_vm_plan_id: 48b35349-d3de-4e19-bc4a-66996ae07766
+      shared_min_port: 1024
+      shared_max_port: 65535
     dedicated_plan:
       instance_count: 3
     shared_plan:

--- a/templates/stubs/cf-redis-jobs.yml
+++ b/templates/stubs/cf-redis-jobs.yml
@@ -29,6 +29,8 @@ properties:
       name: (( .meta.redis.broker.name ))
       service_instance_limit: (( .meta.redis.shared_plan.instance_limit ))
       dedicated_nodes: (( base_jobs.dedicated-node.networks.redis_z1.static_ips ))
+      shared_min_port: (( .meta.redis.broker.shared_min_port ))
+      shared_max_port: (( .meta.redis.broker.shared_max_port ))
     maxmemory: (( .meta.redis.shared_plan.max_memory ))
     host: (( base_jobs.cf-redis-broker.networks.redis_z1.static_ips.[0] ))
     config_command: (( .meta.redis.config_command ))


### PR DESCRIPTION
As documented in https://github.com/pivotal-cf/cf-redis-release/issues/36, this PR adds control to the choice of the port in the precise range.

This is in complement of this PR: https://github.com/pivotal-cf/cf-redis-broker/pull/3

Details over the end-to-end tests performed:

---
## Scenario: **shared instance uses a port in the preferred range**
* given a redis deployment with 
   * redis.broker.shared_min_port=60000 redis.broker.shared_max_port=60000
* when
   * cf bind-service redis-instance app
* then
   * returned port within VCAP_SERVICES is 60000

### Test:
```shell
$ cf cs redis shared-vm myredis
$ cf create-service-key myredis mykey
Creating service key mykey for service instance myredis as ahalet...
OK

$ cf service-key myredis mykey
Getting key mykey for service instance myredis as ahalet...

{
 "host": "10.234.250.160",
 "password": "9babfc50-630e-4f26-bbee-97f1b16ff2a3",
 "port": 60000
}
```

### Result: OK

---
## Scenario: **shared instances rejects service binding when not available port in the preferred range, providing clear error message to service operators and possibly end-users**
* given a redis deployment with 
   * redis.broker.shared_min_port=40000 redis.broker.shared_max_port=40000
* when
   * cf bind-service redis-instance1 app
   * cf bind-service redis-instance2 app
* then
   * ``cf bind-service redis-instance2 app`` fails with error message 
   * redis operator logs contains log entry:

### Test:

```shell
$ cf cs redis shared-vm myredis
Creating service instance myredis in org dfy / space etherpad as ahalet...
OK

$ cf cs redis shared-vm myredis2
Creating service instance myredis2 in org dfy / space etherpad as ahalet...
FAILED
Server error, status code: 502, error code: 10001, message: Service broker error: No port is available in the range. Please ask help to your Operator
```
### Result: OK

---
## Scenario: **operator misconfigurations of preferred port range, fail deployment with clear error message.**
* given a redis deployment descriptor with 
   * redis.broker.shared_min_port=60000 redis.broker.shared_max_port=30000
* when
   * the bosh deploy is requested
* Then
   * the redis-dedicated-job fails to start
   * and the redis-dedicated-job log entry indicates ""

### Test:

```shell
Deploying
---------
bosh-master$ bosh deploy
[...]
  Started updating instance cf-redis-broker > cf-redis-broker/e54249ca-63a8-467a-869c-9c0c992ee26e (0) (canary). Failed: 'cf-redis-broker/0 (e54249ca-63a8-467a-869c-9c0c992ee26e)' is not running after update. Review logs for failed jobs: process-watcher, cf-redis-broker, broker-nginx, route_registrar, syslog-configurator (00:01:58)

Error 400007: 'cf-redis-broker/0 (e54249ca-63a8-467a-869c-9c0c992ee26e)' is not running after update. Review logs for failed jobs: process-watcher, cf-redis-broker, broker-nginx, route_registrar, syslog-configurator

bosh-master$ bosh ssh cf-redis-broker/0

redis-broker$ cat /var/vcap/sys/log/cf-redis-broker/cf-redis-configmigrator.stderr.log
[...]
panic: Not valid range port: minimum port is higher than maximum port
```

### Result: OK

---
## Scenario: **User ask multiple redis**
* given a redis deployment with 
   * redis.broker.shared_min_port=1024 redis.broker.shared_max_port=65535
* when
   * cf bind-service redis-instance1 app
   * cf bind-service redis-instance2 app
* then
   * we should have port 1024 and 1025 taken

### Test:

```shell
$ cf cs redis shared-vm myredis
Creating service instance myredis in org dfy / space etherpad as ahalet...
OK

$ cf cs redis shared-vm myredis2
Creating service instance myredis2 in org dfy / space etherpad as ahalet...
OK

$ cf create-service-key myredis mykey
Creating service key mykey for service instance myredis as ahalet...
OK

$ cf create-service-key myredis2 mykey
Creating service key mykey for service instance myredis2 as ahalet...
OK

$ cf service-key myredis mykey
Getting key mykey for service instance myredis as ahalet...

{
 "host": "10.234.250.160",
 "password": "e062facf-f591-49c0-b75b-d7b474fc70c6",
 "port": 1024
}

$ cf service-key myredis2 mykey
Getting key mykey for service instance myredis2 as ahalet...

{
 "host": "10.234.250.160",
 "password": "c712a7ce-0fcd-477f-afc2-568bb0b2ea3e",
 "port": 1025
}
```

### Result: OK