### PR TITLE
process destroyer should sleep forever

### DIFF
--- a/jobs/cf-redis-broker/templates/process-destroyer_ctl.erb
+++ b/jobs/cf-redis-broker/templates/process-destroyer_ctl.erb
@@ -9,7 +9,7 @@ case $1 in
   start)
     mkdir -p $(dirname $PIDFILE)
     echo $$ > $PIDFILE
-    while true; do exec sleep 10000; done
+    while true; do sleep 10000; done
     ;;
 
   stop)

--- a/jobs/cf-redis-broker/templates/process-destroyer_ctl.erb
+++ b/jobs/cf-redis-broker/templates/process-destroyer_ctl.erb
@@ -9,7 +9,7 @@ case $1 in
   start)
     mkdir -p $(dirname $PIDFILE)
     echo $$ > $PIDFILE
-    while true; do sleep 10000; done
+    while true; do sleep 100; done
     ;;
 
   stop)


### PR DESCRIPTION
exec replaces current script with just "sleep 10000", which exits after 10000 seconds and causes monit restart