### PR TITLE
Update cf-redis-jobs.yml

### DIFF
--- a/templates/stubs/cf-redis-jobs.yml
+++ b/templates/stubs/cf-redis-jobs.yml
@@ -40,7 +40,9 @@ base_releases:
   version: (( .meta.release_version || "latest"))
 - name: routing
   version: 0.162.0
-
+- name: syslog-migration
+  version: latest
+  
 additional_releases: (( merge || [] ))
 
 releases: (( base_releases additional_releases ))


### PR DESCRIPTION
The syslog-migration release specification is missing in the cf-redis-jobs.yml file.