### PR TITLE
Make printing admin creds for debugging optional

### DIFF
--- a/jobs/broker-registrar/spec
+++ b/jobs/broker-registrar/spec
@@ -25,6 +25,9 @@ properties:
     description: 'Basic Auth username for the service broker'
   broker.password:
     description: 'Basic Auth password for the service broker'
+  broker.show_creds:
+    description: 'Show credentials in script output'
+    default: false
   redis.broker.enable_service_access:
     description: 'Enable service access to all orgs specified, default to allow all orgs access'
     default: true

--- a/jobs/broker-registrar/templates/errand.sh.erb
+++ b/jobs/broker-registrar/templates/errand.sh.erb
@@ -3,6 +3,7 @@
 set -e
 set -x
 
+
 export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 
 <% if p("redis.broker.service_instance_limit") == 0 && p("redis.broker.dedicated_node_count") == 0 %>
@@ -10,19 +11,20 @@ export PATH=$PATH:/var/vcap/packages/cf-cli/bin
     exit 0
 <% end %>
 
-
-CF_API_URL='<%= p("cf.api_url") %>'
+<% if !p("broker.show_creds") %>
+  set +x
+<% end %>
+BROKER_USERNAME='<%= p("broker.username") %>'
+BROKER_PASSWORD='<%= p("broker.password") %>'
 CF_ADMIN_USERNAME='<%= p("cf.admin_username") %>'
 CF_ADMIN_PASSWORD='<%= p("cf.admin_password") %>'
+set -x
+
+CF_API_URL='<%= p("cf.api_url") %>'
 CF_DIAL_TIMEOUT=30
 BROKER_NAME='<%= p("broker.name") %>'
 BROKER_SERVICE_NAME='<%= p("redis.broker.service_name") %>'
 BROKER_URL='<%= p("broker.protocol") %>://<%= p("broker.host") %>'
-
-set +x
-BROKER_USERNAME='<%= p("broker.username") %>'
-BROKER_PASSWORD='<%= p("broker.password") %>'
-set -x
 
 SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") ? "--skip-ssl-validation" : "" %>'
 


### PR DESCRIPTION
We noticed that another PR had removed printing of some, but not all creds. We thought an option like this would allow for easier debugging if necessary, but hide creds for security.

Thanks